### PR TITLE
frontend: add offline caching service worker

### DIFF
--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -1,0 +1,69 @@
+const CACHE_NAME = 'self-music-cache-v1';
+const MAX_AGE = 2 * 24 * 60 * 60 * 1000; // 2 days in ms
+
+self.addEventListener('install', (event) => {
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    (async () => {
+      await clients.claim();
+      await cleanupCache();
+    })()
+  );
+});
+
+self.addEventListener('fetch', (event) => {
+  if (event.request.method !== 'GET') {
+    return;
+  }
+
+  event.respondWith(
+    fetch(event.request)
+      .then(async (response) => {
+        const cache = await caches.open(CACHE_NAME);
+        cache.put(event.request, response.clone());
+        await updateTimestamp(event.request, cache);
+        return response;
+      })
+      .catch(async () => {
+        const cache = await caches.open(CACHE_NAME);
+        const cachedResponse = await cache.match(event.request);
+        if (cachedResponse) {
+          return cachedResponse;
+        }
+        return Response.error();
+      })
+  );
+});
+
+async function updateTimestamp(request, cache) {
+  await cache.put(
+    new Request(request.url + '__meta'),
+    new Response(Date.now().toString())
+  );
+}
+
+async function cleanupCache() {
+  const cache = await caches.open(CACHE_NAME);
+  const requests = await cache.keys();
+  const now = Date.now();
+
+  await Promise.all(
+    requests.map(async (request) => {
+      if (request.url.endsWith('__meta')) {
+        return;
+      }
+      const meta = await cache.match(request.url + '__meta');
+      if (!meta) {
+        return;
+      }
+      const fetched = parseInt(await meta.text(), 10);
+      if (now - fetched > MAX_AGE) {
+        await cache.delete(request);
+        await cache.delete(request.url + '__meta');
+      }
+    })
+  );
+}

--- a/frontend/src/components/pwa-provider.tsx
+++ b/frontend/src/components/pwa-provider.tsx
@@ -4,9 +4,15 @@ import { useEffect } from 'react';
 
 export function PWAProvider() {
   useEffect(() => {
-    // 基础PWA支持检测
     if ('serviceWorker' in navigator) {
-      console.log('PWA支持已启用');
+      navigator.serviceWorker
+        .register('/sw.js')
+        .then(() => {
+          console.log('Service Worker registered');
+        })
+        .catch((err) => {
+          console.error('Service Worker registration failed', err);
+        });
     }
   }, []);
 


### PR DESCRIPTION
## Summary
- register service worker in PWA provider
- add service worker caching network requests for two days

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_b_68a4373cae68832bb929ce18232e264c